### PR TITLE
Revise the crate's API to prepare for merging with tokio-retry.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-authors = ["Jimmy Cuadra <jimmy@jimmycuadra.com>"]
-description = "Retry an operation until a condition is true."
-documentation = "https://jimmycuadra.github.io/retry/retry/"
+authors = ["Jimmy Cuadra <jimmy@jimmycuadra.com>", "Sam Rijs <srijs@airpost.net>"]
+description = "Utilities for retrying operations that can fail."
+documentation = "https://docs.rs/retry"
 homepage = "https://github.com/jimmycuadra/retry"
 keywords = ["utility", "utilities"]
 license = "MIT"
@@ -11,4 +11,4 @@ repository = "https://github.com/jimmycuadra/retry"
 version = "0.4.0"
 
 [dependencies]
-rand = "0.3.14"
+rand = "0.3.15"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Jimmy Cuadra
+Copyright (c) 2015-2017 Jimmy Cuadra and Sam Rijs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # retry
 
-A Rust library to retry an operation until a condition is true.
+Crate **retry** provides utilities for retrying operations that can fail.
 
-Documentation: https://jimmycuadra.github.io/retry/retry/
+## Documentation
 
-# License
+retry has [comprehensive documentation](https://docs.rs/retry) available on docs.rs.
 
-[MIT](http://opensource.org/licenses/MIT)
+## Legal
 
+retry is released under the MIT license.
+See `LICENSE`.

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,0 +1,93 @@
+//! Different types of delay for retryable operations.
+
+use std::time::Duration;
+
+use rand::distributions::{IndependentSample, Range as RandRange};
+use rand::thread_rng;
+
+use super::DetermineDelay;
+
+/// Each retry increases the delay since the last exponentially.
+#[derive(Debug)]
+pub struct Exponential {
+    base: u64,
+    current: u64,
+}
+
+impl Exponential {
+    /// Create a new `Exponential` using the given millisecond duration as the initial delay.
+    pub fn from_millis(base: u64) -> Self {
+        Exponential {
+            base: base,
+            current: base,
+        }
+    }
+}
+
+impl DetermineDelay for Exponential {
+    fn next(&mut self) -> Duration {
+        let duration = Duration::from_millis(self.current);
+
+        self.current = self.current * self.base;
+
+        duration
+    }
+}
+
+/// Each retry uses a fixed delay.
+#[derive(Debug)]
+pub struct Fixed {
+    duration: Duration,
+}
+
+impl Fixed {
+    /// Create a new `Fixed` using the given duration in milliseconds.
+    pub fn from_millis(millis: u64) -> Self {
+        Fixed {
+            duration: Duration::from_millis(millis),
+        }
+    }
+}
+
+impl DetermineDelay for Fixed {
+    fn next(&mut self) -> Duration {
+        self.duration
+    }
+}
+
+/// Each retry happens immediately without any delay.
+#[derive(Debug)]
+pub struct NoDelay;
+
+impl DetermineDelay for NoDelay {
+    fn next(&mut self) -> Duration {
+        Duration::default()
+    }
+}
+
+/// Each retry uses a duration randomly chosen from a range.
+#[derive(Debug)]
+pub struct Range {
+    minimum: u64,
+    maximum: u64,
+}
+
+impl Range {
+    /// Create a new `Range` between the given millisecond durations.
+    pub fn from_millis(minimum: u64, maximum: u64) -> Self {
+        Range {
+            minimum: minimum,
+            maximum: maximum,
+        }
+    }
+}
+
+impl DetermineDelay for Range {
+    fn next(&mut self) -> Duration {
+        let range = RandRange::new(self.minimum, self.maximum);
+
+        let mut rng = thread_rng();
+
+        Duration::from_millis(range.ind_sample(&mut rng))
+    }
+}

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -5,8 +5,6 @@ use std::time::Duration;
 use rand::distributions::{IndependentSample, Range as RandRange};
 use rand::thread_rng;
 
-use super::DetermineDelay;
-
 /// Each retry increases the delay since the last exponentially.
 #[derive(Debug)]
 pub struct Exponential {
@@ -24,13 +22,15 @@ impl Exponential {
     }
 }
 
-impl DetermineDelay for Exponential {
-    fn next(&mut self) -> Duration {
+impl Iterator for Exponential {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Duration> {
         let duration = Duration::from_millis(self.current);
 
         self.current = self.current * self.base;
 
-        duration
+        Some(duration)
     }
 }
 
@@ -49,9 +49,11 @@ impl Fixed {
     }
 }
 
-impl DetermineDelay for Fixed {
-    fn next(&mut self) -> Duration {
-        self.duration
+impl Iterator for Fixed {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Duration> {
+        Some(self.duration)
     }
 }
 
@@ -59,9 +61,11 @@ impl DetermineDelay for Fixed {
 #[derive(Debug)]
 pub struct NoDelay;
 
-impl DetermineDelay for NoDelay {
-    fn next(&mut self) -> Duration {
-        Duration::default()
+impl Iterator for NoDelay {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Duration> {
+        Some(Duration::default())
     }
 }
 
@@ -82,12 +86,14 @@ impl Range {
     }
 }
 
-impl DetermineDelay for Range {
-    fn next(&mut self) -> Duration {
+impl Iterator for Range {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Duration> {
         let range = RandRange::new(self.minimum, self.maximum);
 
         let mut rng = thread_rng();
 
-        Duration::from_millis(range.ind_sample(&mut rng))
+        Some(Duration::from_millis(range.ind_sample(&mut rng)))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ where I: IntoIterator<Item=Duration>, O: FnMut() -> Result<R, E> {
                 if let Some(delay) = iterator.next() {
                     sleep(delay);
                     try += 1;
-                    total_delay = delay;
+                    total_delay += delay;
                 } else {
                     return Err(Error::Operation {
                         error: error,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,9 @@ pub mod delay;
 
 /// Retry the given operation synchronously until it succeeds, or until the given `Duration`
 /// iterator ends.
-pub fn retry<I, O, R, E>(mut iterator: I, mut operation: O) -> Result<R, Error<E>>
-where I: Iterator<Item=Duration>, O: FnMut() -> Result<R, E> {
+pub fn retry<I, O, R, E>(iterable: I, mut operation: O) -> Result<R, Error<E>>
+where I: IntoIterator<Item=Duration>, O: FnMut() -> Result<R, E> {
+    let mut iterator = iterable.into_iter();
     let mut try = 1;
     let mut total_delay = Duration::default();
 


### PR DESCRIPTION
Here's a revision of the whole crate's API to be more in line with tokio-retry's API. My goal was to be able to land this (along with any changes decided upon during review) and then have async stuff implemented in a separate PR after this.

Notable changes from tokio-retry's current API, none of which I'm necessarily married to:

* Decorators are not used for limits or jitter. It seemed like a simpler API to just have those things configured via the `Retry` object. I'm not sure the extra abstraction buys much.
* `RetryStrategy` is called `DetermineDelay`, based on the stylistic suggestion "[prefer transitive verbs, nouns, and then adjectives; avoid suffixes like `able`](https://aturon.github.io/style/naming.html)". This is a bit of a mouthful so I'm not sure it was good change, but it is more descriptive about what it does.

I updated all the docs and tests, too, so it might be easiest to review by `cargo doc`ing and looking through the rustdocs before looking at code.

Jitter is not actually implemented, even though there's a method for it. That still needs to be done, though not necessarily as part of this PR.

Note also that `maximum_delay_per_try` is configurable, but not `maximum_delay`, because right now the code is not doing anything to track the entire elapsed time. I'm not sure the former is actually a useful feature. If not, we can think of it as a placeholder for the latter feature. This also affects the `total_delay` field in `Error::Operation`.

Lastly, there is a no-op method, `Retry::run_async`, which was my idea for how the same `Retry` type might expose both a sync and async interface. I didn't think too hard about whether or not the details of `DetermineDelay` implementations might make it hard or impossible to use them for only sync or async, but not both, in which case this API won't really work.