### PR TITLE
Fix #19: Permit exiting early without more retries

### DIFF
--- a/src/opresult.rs
+++ b/src/opresult.rs
@@ -1,0 +1,40 @@
+//! Provides a ternary result for operations
+//!
+//! # Examples
+//!
+//! ```rust
+//! # use retry::retry;
+//! # use retry::delay::Fixed;
+//! use retry::OperationResult;
+//! let mut collection = vec![1, 2].into_iter();
+//! let value = retry(Fixed::from_millis(1), || {
+//!     match collection.next() {
+//!         Some(n) if n == 2 => OperationResult::Ok(n),
+//!         Some(_) => OperationResult::Retry("not 2"),
+//!         None => OperationResult::Err("not found"),
+//!         }
+//!     }).unwrap();
+//!
+//! assert_eq!(value, 2);
+//! ```
+
+/// `OperationResult` is a type that represents either success ([`Ok`]) or
+/// failure ([`Err`]) or possible failure that should be retried ([`Retry`]).
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
+pub enum OperationResult<T, E> {
+    /// Contains the success value
+    Ok(T),
+    /// Contains the error value if duration is exceeded
+    Retry(E),
+    /// Contains an immediate error value
+    Err(E),
+}
+
+impl<T, E> From<Result<T, E>> for OperationResult<T, E> {
+    fn from(item: Result<T, E>) -> Self {
+        match item {
+            Ok(v) => OperationResult::Ok(v),
+            Err(e) => OperationResult::Retry(e),
+        }
+    }
+}


### PR DESCRIPTION
This is important for many cases where only some cases are safe to
retry (e.g. non idempotent HTTP operations), or file system operations
where unknown errors are undefined behaviour.

Signed-off-by: Robert Collins <robertc@robertcollins.net>