### PR TITLE
Implement From<Duration> for Fixed

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -126,6 +126,14 @@ impl Iterator for Fixed {
     }
 }
 
+impl From<Duration> for Fixed {
+    fn from(delay: Duration) -> Self {
+        Self {
+            duration: delay.into(),
+        }
+    }
+}
+
 /// Each retry happens immediately without any delay.
 #[derive(Debug)]
 pub struct NoDelay;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,14 @@ mod tests {
     }
 
     #[test]
+    fn fixed_delay_from_duration() {
+        assert_eq!(
+            Fixed::from_millis(1_000).next(),
+            Fixed::from(Duration::from_secs(1)).next(),
+        );
+    }
+
+    #[test]
     fn succeeds_with_exponential_delay() {
         let mut collection = vec![1, 2].into_iter();
 


### PR DESCRIPTION
Now that `Duration` can be constructed with a const fn, code like

```rust
    const RETRY_WAIT_MS: usize = 1000;
    retry(Fixed::from_millis(RETRY_WAIT_MS), …)
```
can be converted to the more ergonomic

```rust
	pub const RETRY_WAIT: Duration = Duration::from_secs(1);
```
But because [`Fixed::from_millis`](http://doc.rust-lang.org/std/time/struct.Duration.html#method.from_millis) accepts `u64` and [`Duration::as_millis`](http://doc.rust-lang.org/std/time/struct.Duration.html#method.as_millis)
returns `u128`, this is awkward to use. Adding conversion from `Duration`
allows for:
```rust
    retry(Fixed::from(RETRY_WAIT), …)
```