### PR TITLE
`#![deny(warning)]` considered harmful

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@
 //! assert_eq!(value, 2);
 //! ```
 
-#![deny(missing_debug_implementations, missing_docs)]
+#![deny(missing_debug_implementations, missing_docs, warnings)]
 
 use std::{
     error::Error as StdError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@
 //! assert_eq!(value, 2);
 //! ```
 
-#![deny(missing_debug_implementations, missing_docs, warnings)]
+#![deny(missing_debug_implementations, missing_docs)]
 
 use std::{
     error::Error as StdError,
@@ -182,7 +182,7 @@ where
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match *self {
             Error::Operation { ref error, .. } => Some(error),
             Error::Internal(_) => None,


### PR DESCRIPTION
See also https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md.
Denying warning makes non-breaking changes breaking.

As the proof of it, current master doesn't compile with latest rustc because `&Trait` is warned.