### PR TITLE
revise asynchronous module with latest async echosystems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ version = "1.0.0"
 
 [dependencies]
 rand = "0.7.3"
+futures = "0.3"
+
+[dev-dependencies]
+tokio = { version = "0.2" , features = ["time", "rt-threaded", "macros"]}

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -3,225 +3,277 @@
 //! # Examples
 //!
 //! ```rust
-//! # extern crate futures;
-//! # extern crate tokio_timer;
-//! # extern crate retry;
 //! # use futures::future::Future;
-//! use tokio_timer::Timer;
+//! use tokio::time::delay_for;
 //! use retry::delay::{Exponential, jitter};
-//! use retry::async::retry;
-//!
-//! pub fn main() {
-//!     let timer = Timer::default();
+//! use retry::asynchronous::retry;
+//! #[tokio::main]
+//! pub async fn main() {
+//!     let timer = delay_for;
 //!     let delay = Exponential::from_millis(10)
 //!         .map(jitter).take(3);
 //!
 //!     let mut collection = vec![1, 2, 3].into_iter();
 //!
-//!     let future = retry(timer, delay, || {
-//!         match collection.next() {
-//!             Some(n) if n == 3 => Ok("n is 3!"),
-//!             Some(_) => Err("n must be 3!"),
-//!             None => Err("n was never 3!"),
+//!     let future = retry(timer, delay, move || {
+//!         let next = collection.next();
+//!         async move {
+//!             match next {
+//!                 Some(n) if n == 3 => Ok("n is 3!"),
+//!                 Some(_) => Err("n must be 3!"),
+//!                 None => Err("n was never 3!"),
+//!             }
 //!         }
 //!     });
 //!
-//!     let result = future.wait();
+//!     let result = future.await;
 //!
 //!     assert!(result.is_ok());
 //! }
 //! ```
 
-use std::error::{Error as StdError};
-use std::io::{Error as IoError};
-use std::fmt::{Debug, Error as FmtError, Formatter};
-use std::time::Duration;
-
-use futures::{Async, IntoFuture, Future, Poll};
-use futures::future::{Either, Flatten, FutureResult};
-#[cfg(feature = "async_tokio_timer")]
-use tokio_timer::{Timer, TimerError, Sleep as TimerSleep};
-#[cfg(feature = "async_tokio_core")]
-use tokio_core::reactor::{Handle as ReactorHandle, Timeout as ReactorTimeout};
-
 use super::Error;
+use futures::TryFuture;
+use std::fmt::{Debug, Error as FmtError, Formatter};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
 
 /// Produce a future that resolves after a given delay.
 pub trait Sleep {
-    /// The type of error that the future will result in if it fails.
-    type Error: StdError;
     /// The future that `sleep` will return.
-    type Future: Future<Error = Self::Error>;
+    type Future: Future<Output = ()>;
     /// Returns a future that will resolve after a given delay.
     fn sleep(&mut self, duration: Duration) -> Self::Future;
 }
 
-#[cfg(feature = "async_tokio_timer")]
-impl Sleep for Timer {
-    type Error = TimerError;
-    type Future = TimerSleep;
+impl<Fn, Fut> Sleep for Fn
+where
+    Fn: FnMut(Duration) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    type Future = Fut;
     fn sleep(&mut self, duration: Duration) -> Self::Future {
-        Timer::sleep(self, duration)
+        (self)(duration)
     }
 }
-
-#[cfg(feature = "async_tokio_core")]
-impl Sleep for ReactorHandle {
-    type Error = IoError;
-    type Future = Flatten<FutureResult<ReactorTimeout, IoError>>;
-    fn sleep(&mut self, duration: Duration) -> Self::Future {
-        ReactorTimeout::new(duration, self).into_future().flatten()
-    }
-}
-
 /// Keep track of the state of our future, whether it
 /// currently sleeps or executes the operation.
-enum RetryState<S, A> where S: Sleep, A: IntoFuture {
-    Running(A::Future),
-    Sleeping(S::Future)
+enum RetryState<S, A>
+where
+    S: Sleep,
+    A: TryFuture,
+{
+    Running(A),
+    Sleeping(S::Future),
 }
 
 /// Future that drives multiple attempts at an operation.
-pub struct RetryFuture<S, I, O, A> where S: Sleep, I: IntoIterator<Item = Duration>, A: IntoFuture, O: FnMut() -> A {
+pub struct RetryFuture<S, I, O, A>
+where
+    S: Sleep,
+    I: IntoIterator<Item = Duration>,
+    A: TryFuture,
+    O: FnMut() -> A,
+{
     delay: I::IntoIter,
     state: RetryState<S, A>,
     operation: O,
     sleep: S,
     total_delay: Duration,
-    tries: u64
+    tries: u64,
 }
 
-impl<S, I, O, A> Debug for RetryFuture<S, I, O, A> where S: Sleep, I: IntoIterator<Item = Duration>, A: IntoFuture, O: FnMut() -> A {
+impl<S, I, O, A> Debug for RetryFuture<S, I, O, A>
+where
+    S: Sleep,
+    I: IntoIterator<Item = Duration>,
+    A: TryFuture,
+    O: FnMut() -> A,
+{
     fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
-        write!(f, "RetryFuture {{ total_delay: {:?}, tries: {:?} }}", self.total_delay, self.tries)
+        write!(
+            f,
+            "RetryFuture {{ total_delay: {:?}, tries: {:?} }}",
+            self.total_delay, self.tries
+        )
     }
 }
 
 /// Retry the given operation asynchronously until it succeeds, or until the given Duration iterator ends.
-pub fn retry<S, I, O, A>(sleep: S, iterable: I, operation: O) -> RetryFuture<S, I, O, A> where S: Sleep, I: IntoIterator<Item = Duration>, A: IntoFuture, O: FnMut() -> A {
+pub fn retry<S, I, O, A>(sleep: S, iterable: I, operation: O) -> RetryFuture<S, I, O, A>
+where
+    S: Sleep,
+    I: IntoIterator<Item = Duration>,
+    A: TryFuture,
+    O: FnMut() -> A,
+{
     RetryFuture::spawn(sleep, iterable, operation)
 }
 
-impl<S, I, O, A> RetryFuture<S, I, O, A> where S: Sleep, I: IntoIterator<Item = Duration>, A: IntoFuture, O: FnMut() -> A {
+impl<S, I, O, A> RetryFuture<S, I, O, A>
+where
+    S: Sleep,
+    I: IntoIterator<Item = Duration>,
+    A: TryFuture,
+    O: FnMut() -> A,
+{
     fn spawn(sleep: S, iterable: I, mut operation: O) -> RetryFuture<S, I, O, A> {
         RetryFuture {
             delay: iterable.into_iter(),
-            state: RetryState::Running(operation().into_future()),
-            operation: operation,
-            sleep: sleep,
+            state: RetryState::Running(operation()),
+            operation,
+            sleep,
             total_delay: Duration::default(),
-            tries: 1
+            tries: 1,
         }
     }
 
-    fn attempt(&mut self) -> Poll<A::Item, Error<A::Error>> {
-        let future = (self.operation)().into_future();
+    fn attempt(&mut self) {
+        let future = (self.operation)();
         self.state = RetryState::Running(future);
-        return self.poll();
     }
 
-    fn retry(&mut self, err: A::Error) -> Poll<A::Item, Error<A::Error>> {
+    fn retry(&mut self, err: A::Error) -> Result<(), Error<A::Error>> {
         match self.delay.next() {
-            None => Err(Error::Operation{
+            None => Err(Error::Operation {
                 error: err,
                 total_delay: self.total_delay,
-                tries: self.tries
+                tries: self.tries,
             }),
             Some(duration) => {
                 self.total_delay += duration;
                 self.tries += 1;
                 let future = self.sleep.sleep(duration);
                 self.state = RetryState::Sleeping(future);
-                return self.poll();
+                Ok(())
             }
         }
     }
 }
 
-impl<S, I, O, A> Future for RetryFuture<S, I, O, A> where S: Sleep, I: IntoIterator<Item = Duration>, A: IntoFuture, O: FnMut() -> A {
-    type Item = A::Item;
-    type Error = Error<A::Error>;
+impl<S, I, O, A> Future for RetryFuture<S, I, O, A>
+where
+    S: Sleep,
+    I: IntoIterator<Item = Duration>,
+    A: TryFuture,
+    O: FnMut() -> A,
+{
+    type Output = Result<A::Ok, Error<A::Error>>;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let result = match self.state {
-            RetryState::Running(ref mut future) =>
-                Either::A(future.poll()),
-            RetryState::Sleeping(ref mut future) =>
-                Either::B(future.poll())
-        };
-
-        match result {
-            Either::A(poll_result) => match poll_result {
-                Ok(async) => Ok(async),
-                Err(err) => self.retry(err)
-            },
-            Either::B(poll_result) => {
-                let poll_async = poll_result
-                    .map_err(|err| Error::Internal(err.description().to_string()))?;
-
-                match poll_async {
-                    Async::NotReady => Ok(Async::NotReady),
-                    Async::Ready(_) => self.attempt()
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        unsafe {
+            // 1. Making `Pin`ned projection of state
+            match &mut Pin::get_unchecked_mut(self.as_mut()).state {
+                RetryState::Running(future) => {
+                    let future = Pin::new_unchecked(future);
+                    let result = future.try_poll(cx);
+                    match result {
+                        Poll::Ready(Ok(r#async)) => Poll::Ready(Ok(r#async)),
+                        Poll::Ready(Err(err)) => {
+                            // 2.a Mutating state as if it is unpinned.
+                            //     Generally speaking, it is unsafe, but safe in this time.
+                            //     As the future in `state` is "done" and will not be used anymore,
+                            //     discarding it is safe
+                            match Pin::get_unchecked_mut(self.as_mut()).retry(err) {
+                                Ok(()) => self.poll(cx),
+                                Err(e) => Poll::Ready(Err(e)),
+                            }
+                        }
+                        Poll::Pending => Poll::Pending,
+                    }
+                }
+                RetryState::Sleeping(future) => {
+                    let future = Pin::new_unchecked(future);
+                    let result = future.poll(cx);
+                    match result {
+                        Poll::Pending => Poll::Pending,
+                        Poll::Ready(()) => {
+                            // 2.b Same as 2.a
+                            Pin::get_unchecked_mut(self.as_mut()).attempt();
+                            self.poll(cx)
+                        }
+                    }
                 }
             }
         }
     }
 }
 
-#[test]
-fn attempts_just_once() {
-    use std::iter::empty;
-    let delay = empty();
-    let mut num_calls = 0;
-    let timer = Timer::default();
-    let res = retry(timer, delay, || {
-        num_calls += 1;
-        Err::<(), u64>(42)
-    }).wait();
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[tokio::test]
+    async fn attempts_just_once() {
+        use futures::future::err;
+        use std::iter::empty;
+        use tokio::time::delay_for;
+        let delay = empty();
+        let mut num_calls = 0;
+        let timer = delay_for;
+        let res = retry(timer, delay, || {
+            num_calls += 1;
+            err::<(), u64>(42)
+        })
+        .await;
 
-    assert_eq!(num_calls, 1);
-    assert_eq!(res, Err(Error::Operation{
-        error: 42,
-        tries: 1,
-        total_delay: Duration::from_millis(0)
-    }));
-}
+        assert_eq!(num_calls, 1);
+        assert_eq!(
+            res,
+            Err(Error::Operation {
+                error: 42,
+                tries: 1,
+                total_delay: Duration::from_millis(0)
+            })
+        );
+    }
 
-#[test]
-fn attempts_until_max_retries_exceeded() {
-    use std::time::Duration;
-    use super::delay::Fixed;
-    let timer = Timer::default();
-    let delay = Fixed::from_millis(100).take(2);
-    let mut num_calls = 0;
-    let res = retry(timer, delay, || {
-        num_calls += 1;
-        Err::<(), u64>(42)
-    }).wait();
+    #[tokio::test]
+    async fn attempts_until_max_retries_exceeded() {
+        use crate::delay::Fixed;
+        use futures::future::err;
+        use std::time::Duration;
+        use tokio::time::delay_for;
+        let timer = delay_for;
+        let delay = Fixed::from_millis(100).take(2);
+        let mut num_calls = 0;
+        let res = retry(timer, delay, || {
+            num_calls += 1;
+            err::<(), u64>(42)
+        })
+        .await;
 
-    assert_eq!(num_calls, 3);
-    assert_eq!(res, Err(Error::Operation{
-        error: 42,
-        tries: 3,
-        total_delay: Duration::from_millis(200)
-    }));
-}
+        assert_eq!(num_calls, 3);
+        assert_eq!(
+            res,
+            Err(Error::Operation {
+                error: 42,
+                tries: 3,
+                total_delay: Duration::from_millis(200)
+            })
+        );
+    }
 
-#[test]
-fn attempts_until_success() {
-    use super::delay::Fixed;
-    let timer = Timer::default();
-    let delay = Fixed::from_millis(100);
-    let mut num_calls = 0;
-    let res = retry(timer, delay, || {
-        num_calls += 1;
-        if num_calls < 4 {
-            Err::<(), u64>(42)
-        } else {
-            Ok::<(), u64>(())
-        }
-    }).wait();
+    #[tokio::test]
+    async fn attempts_until_success() {
+        use crate::delay::Fixed;
+        use futures::future::{err, ok};
+        use tokio::time::delay_for;
+        let timer = delay_for;
+        let delay = Fixed::from_millis(100);
+        let mut num_calls = 0;
+        let res = retry(timer, delay, || {
+            num_calls += 1;
+            if num_calls < 4 {
+                err::<(), u64>(42)
+            } else {
+                ok::<(), u64>(())
+            }
+        })
+        .await;
 
-    assert_eq!(res, Ok(()));
-    assert_eq!(num_calls, 4);
+        assert_eq!(res, Ok(()));
+        assert_eq!(num_calls, 4);
+    }
 }


### PR DESCRIPTION
This is yet another implementation of async retry.
Unlike #24, This PR doesn't depends on any async runtimes.

I respected existing module and carefully reused it. However, if you like clean async/await implementation like #24, I'll rewrite this.