### PR TITLE
Add a configurable multiplication factor in `Exponential` delay

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -14,16 +14,24 @@ use rand::{
 /// Each retry increases the delay since the last exponentially.
 #[derive(Debug)]
 pub struct Exponential {
-    base: u64,
     current: u64,
+    factor: f64,
 }
 
 impl Exponential {
     /// Create a new `Exponential` using the given millisecond duration as the initial delay.
     pub fn from_millis(base: u64) -> Self {
         Exponential {
-            base,
             current: base,
+            factor: base as f64,
+        }
+    }
+
+    /// Create a new `Exponential` using the given millisecond duration as the initial delay and a variable multiplication factor.
+    pub fn from_millis_with_factor(base: u64, factor: f64) -> Self {
+        Exponential {
+            current: base,
+            factor,
         }
     }
 }
@@ -34,11 +42,12 @@ impl Iterator for Exponential {
     fn next(&mut self) -> Option<Duration> {
         let duration = Duration::from_millis(self.current);
 
-        if let Some(next) = self.current.checked_mul(self.base) {
-            self.current = next;
+        let next = (self.current as f64) * self.factor;
+        self.current = if next > (U64_MAX as f64) {
+            U64_MAX
         } else {
-            self.current = U64_MAX;
-        }
+            next as u64
+        };
 
         Some(duration)
     }
@@ -48,6 +57,24 @@ impl From<Duration> for Exponential {
     fn from(duration: Duration) -> Self {
         Self::from_millis(duration.as_millis() as u64)
     }
+}
+
+#[test]
+fn exponential_with_factor() {
+    let mut iter = Exponential::from_millis_with_factor(1000, 2.0);
+    assert_eq!(iter.next(), Some(Duration::from_millis(1000)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(2000)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(4000)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(8000)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(16000)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(32000)));
+}
+
+#[test]
+fn exponential_overflow() {
+    let mut iter = Exponential::from_millis(U64_MAX);
+    assert_eq!(iter.next(), Some(Duration::from_millis(U64_MAX)));
+    assert_eq!(iter.next(), Some(Duration::from_millis(U64_MAX)));
 }
 
 /// Each retry uses a delay which is the sum of the two previous delays.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,7 @@ impl<E> Display for Error<E>
 where
     E: StdError,
 {
+    #[allow(deprecated)]
     fn fmt(&self, formatter: &mut Formatter) -> Result<(), FmtError> {
         write!(formatter, "{}", self.description())
     }
@@ -212,6 +213,7 @@ impl<E> StdError for Error<E>
 where
     E: StdError,
 {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         match *self {
             Error::Operation { ref error, .. } => error.description(),
@@ -334,6 +336,23 @@ mod tests {
             Some(_) => Err("not 2"),
             None => Err("not 2"),
         })
+        .unwrap();
+
+        assert_eq!(value, 2);
+    }
+
+    #[test]
+    fn succeeds_with_exponential_delay_with_factor() {
+        let mut collection = vec![1, 2].into_iter();
+
+        let value = retry(
+            Exponential::from_millis_with_factor(1000, 2.0),
+            || match collection.next() {
+                Some(n) if n == 2 => Ok(n),
+                Some(_) => Err("not 2"),
+                None => Err("not 2"),
+            },
+        )
         .unwrap();
 
         assert_eq!(value, 2);


### PR DESCRIPTION
This closes #23 and adds a new constructor to Exponential delays that allows specifying the factor of multiplication instead of using the base as the factor. In particular for retrying API responses it is desirable to use a lesser factor as otherwise the time to wait increases far too quickly to be useable.

I added two allows for deprecation because Rust recently deprecated some method (ref: https://github.com/rust-lang/rust/pull/66919). Please advise if you would like to see this handled differently. I suppose for early rust version support they might still be required, so I did not want to remove them completely.