### PR TITLE
Default factor = 2 for the exponential increment

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -20,10 +20,11 @@ pub struct Exponential {
 
 impl Exponential {
     /// Create a new `Exponential` using the given millisecond duration as the initial delay.
+    /// The value will be incremented by a factor of 2 at every retry.
     pub fn from_millis(base: u64) -> Self {
         Exponential {
             current: base,
-            factor: base as f64,
+            factor: 2.0,
         }
     }
 


### PR DESCRIPTION
Having the factor that will be used for the exponential equal to the base might incur in unwanted behaviour, since this was not present in the documentation and it requires to read the source code.
A default factor = the base might cause a very high variability i.e. outputs that are hard to predict and possibly too large retries.
Assume that we have a base of 1000ms and we want to retry 3 times: the first retry will happen after 1 sec, the second retry after 1000s ~= 16 mins, the third retry will happen after 1e6s ~= 11.5 days. 
Assume on the other hand that the base is 1ms, all the next retries will happen after 1ms, i.e. a constant pattern. I am not sure this should be the default.
If we default to a factor of 2 (or another const value) we will have a more predictable pattern that might produce a better default. If we take the example above, 1s 3 retries: first retry after 1s, second after 2s, third after 4s.