### PR TITLE
Make rand crate can be opt-out

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,8 @@ repository = "https://github.com/jimmycuadra/retry"
 version = "1.1.0"
 
 [dependencies]
-rand = "0.7.3"
+rand = { version = "0.7.3", optional = true }
+
+[features]
+default = ["random"]
+random = ["rand"]

--- a/src/delay/mod.rs
+++ b/src/delay/mod.rs
@@ -1,15 +1,13 @@
 //! Different types of delay for retryable operations.
 
-use std::ops::{Range as StdRange, RangeInclusive};
 use std::time::Duration;
 use std::u64::MAX as U64_MAX;
 
-use rand::{
-    distributions::{Distribution, Uniform},
-    random,
-    rngs::ThreadRng,
-    thread_rng,
-};
+#[cfg(feature = "random")]
+mod random;
+
+#[cfg(feature = "random")]
+pub use random::{jitter, Range};
 
 /// Each retry increases the delay since the last exponentially.
 #[derive(Debug)]
@@ -184,70 +182,4 @@ impl Iterator for NoDelay {
     fn next(&mut self) -> Option<Duration> {
         Some(Duration::default())
     }
-}
-
-/// Each retry uses a duration randomly chosen from a range.
-#[derive(Debug)]
-pub struct Range {
-    distribution: Uniform<u64>,
-    rng: ThreadRng,
-}
-
-impl Range {
-    /// Create a new `Range` between the given millisecond durations, excluding the maximum value.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the minimum is greater than or equal to the maximum.
-    pub fn from_millis_exclusive(minimum: u64, maximum: u64) -> Self {
-        Range {
-            distribution: Uniform::new(minimum, maximum),
-            rng: thread_rng(),
-        }
-    }
-
-    /// Create a new `Range` between the given millisecond durations, including the maximum value.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the minimum is greater than or equal to the maximum.
-    pub fn from_millis_inclusive(minimum: u64, maximum: u64) -> Self {
-        Range {
-            distribution: Uniform::new_inclusive(minimum, maximum),
-            rng: thread_rng(),
-        }
-    }
-}
-
-impl Iterator for Range {
-    type Item = Duration;
-
-    fn next(&mut self) -> Option<Duration> {
-        Some(Duration::from_millis(
-            self.distribution.sample(&mut self.rng),
-        ))
-    }
-}
-
-impl From<StdRange<Duration>> for Range {
-    fn from(range: StdRange<Duration>) -> Self {
-        Self::from_millis_exclusive(range.start.as_millis() as u64, range.end.as_millis() as u64)
-    }
-}
-
-impl From<RangeInclusive<Duration>> for Range {
-    fn from(range: RangeInclusive<Duration>) -> Self {
-        Self::from_millis_inclusive(
-            range.start().as_millis() as u64,
-            range.end().as_millis() as u64,
-        )
-    }
-}
-
-/// Apply full random jitter to a duration.
-pub fn jitter(duration: Duration) -> Duration {
-    let jitter = random::<f64>();
-    let secs = ((duration.as_secs() as f64) * jitter).ceil() as u64;
-    let nanos = ((f64::from(duration.subsec_nanos())) * jitter).ceil() as u32;
-    Duration::new(secs, nanos)
 }

--- a/src/delay/random.rs
+++ b/src/delay/random.rs
@@ -1,0 +1,77 @@
+use std::{
+    ops::{Range as StdRange, RangeInclusive},
+    time::Duration,
+};
+
+use rand::{
+    distributions::{Distribution, Uniform},
+    random,
+    rngs::ThreadRng,
+    thread_rng,
+};
+
+/// Each retry uses a duration randomly chosen from a range. (need `random` feature)
+#[derive(Debug)]
+pub struct Range {
+    distribution: Uniform<u64>,
+    rng: ThreadRng,
+}
+
+impl Range {
+    /// Create a new `Range` between the given millisecond durations, excluding the maximum value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the minimum is greater than or equal to the maximum.
+    pub fn from_millis_exclusive(minimum: u64, maximum: u64) -> Self {
+        Range {
+            distribution: Uniform::new(minimum, maximum),
+            rng: thread_rng(),
+        }
+    }
+
+    /// Create a new `Range` between the given millisecond durations, including the maximum value.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the minimum is greater than or equal to the maximum.
+    pub fn from_millis_inclusive(minimum: u64, maximum: u64) -> Self {
+        Range {
+            distribution: Uniform::new_inclusive(minimum, maximum),
+            rng: thread_rng(),
+        }
+    }
+}
+
+impl Iterator for Range {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Duration> {
+        Some(Duration::from_millis(
+            self.distribution.sample(&mut self.rng),
+        ))
+    }
+}
+
+impl From<StdRange<Duration>> for Range {
+    fn from(range: StdRange<Duration>) -> Self {
+        Self::from_millis_exclusive(range.start.as_millis() as u64, range.end.as_millis() as u64)
+    }
+}
+
+impl From<RangeInclusive<Duration>> for Range {
+    fn from(range: RangeInclusive<Duration>) -> Self {
+        Self::from_millis_inclusive(
+            range.start().as_millis() as u64,
+            range.end().as_millis() as u64,
+        )
+    }
+}
+
+/// Apply full random jitter to a duration. (need `random` feature)
+pub fn jitter(duration: Duration) -> Duration {
+    let jitter = random::<f64>();
+    let secs = ((duration.as_secs() as f64) * jitter).ceil() as u64;
+    let nanos = ((f64::from(duration.subsec_nanos())) * jitter).ceil() as u32;
+    Duration::new(secs, nanos)
+}


### PR DESCRIPTION
Consider "random duration" not the essential part of retrying. The dependency of `rand` crate are not always necessary.

This PR try to make `rand` dependency can be opt-out by downstream user.

Basically, This PR create a new feature `random`, and keep `Range` & `jitter` behind the feature gate. New feature are on by default, so this change would not break any original usage. All test case are passed.

You can check by following command:

```sh
// opt-out rand crate
cargo test --no-default-features
cargo doc --no-default-features --open

// original
cargo test
cargo doc --open
```

If you think that is OK, please merge it.

Anyway, thanks your nice crate :)