### PR TITLE
Fixes to Display impl of retry::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,9 +212,11 @@ impl<E> Display for Error<E>
 where
     E: StdError,
 {
-    #[allow(deprecated)]
     fn fmt(&self, formatter: &mut Formatter) -> Result<(), FmtError> {
-        write!(formatter, "{}", self.description())
+        match self {
+            Error::Operation { error, .. } => Display::fmt(error, formatter),
+            Error::Internal(description) => formatter.write_str(description),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ pub enum Error<E> {
 
 impl<E> Display for Error<E>
 where
-    E: StdError,
+    E: Display,
 {
     fn fmt(&self, formatter: &mut Formatter) -> Result<(), FmtError> {
         match self {


### PR DESCRIPTION
### The first commit fixes #33.

```rust
println!("{}", retry::Error::Operation {
    error: serde_json::from_str::<i32>("").unwrap_err(),
    total_delay: std::time::Duration::default(),
    tries: 1,
});
```

**Before:**

```console
description() is deprecated; use Display
```

**After:**

```console
EOF while parsing a value at line 1 column 0
```

<br>

### The second commit fixes #34.

```rust
println!("{}", retry::Error::Operation {
    error: Box::<dyn std::error::Error>::from(":("),
    total_delay: std::time::Duration::default(),
    tries: 1,
});
```

**Before:**

```console
error[E0277]: the size for values of type `dyn std::error::Error` cannot be known at compilation time
 --> src/main.rs:2:20
  |
2 |       println!("{}", retry::Error::Operation {
  |  ____________________^
3 | |         error: Box::<dyn std::error::Error>::from(":("),
4 | |         total_delay: std::time::Duration::default(),
5 | |         tries: 1,
6 | |     });
  | |_____^ doesn't have a size known at compile-time
  |
  = help: the trait `Sized` is not implemented for `dyn std::error::Error`
  = note: required because of the requirements on the impl of `std::error::Error` for `Box<dyn std::error::Error>`
  = note: required because of the requirements on the impl of `std::fmt::Display` for `retry::Error<Box<dyn std::error::Error>>`
  = note: required by `std::fmt::Display::fmt`
  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

**After:**

```console
:(
```