### PR TITLE
Bump rand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/jimmycuadra/retry"
 version = "1.3.0"
 
 [dependencies]
-rand = { version = "0.7.3", optional = true }
+rand = { version = "^0.8", optional = true }
 
 [features]
 default = ["random"]

--- a/src/delay/random.rs
+++ b/src/delay/random.rs
@@ -85,7 +85,7 @@ fn range_uniform() {
 }
 
 #[test]
-#[should_panic()]
+#[should_panic]
 fn range_uniform_wrong_input() {
     Range::from_millis_exclusive(0, 0);
 }

--- a/src/delay/random.rs
+++ b/src/delay/random.rs
@@ -75,3 +75,23 @@ pub fn jitter(duration: Duration) -> Duration {
     let nanos = ((f64::from(duration.subsec_nanos())) * jitter).ceil() as u32;
     Duration::new(secs, nanos)
 }
+
+#[test]
+fn range_uniform() {
+    let mut range = Range::from_millis_exclusive(0, 1);
+    assert_eq!(Duration::from_millis(0), range.next().unwrap());
+    assert_eq!(Duration::from_millis(0), range.next().unwrap());
+    assert_eq!(Duration::from_millis(0), range.next().unwrap());
+}
+
+#[test]
+#[should_panic()]
+fn range_uniform_wrong_input() {
+    Range::from_millis_exclusive(0, 0);
+}
+
+#[test]
+fn test_jitter() {
+    assert_eq!(Duration::from_millis(0), jitter(Duration::from_millis(0)));
+    assert!(Duration::from_millis(0) < jitter(Duration::from_millis(2)));
+}


### PR DESCRIPTION
Upgrade the rand version from `0.7.3` to `^0.8` so we are free of a vulnerable [dependencies](https://rustsec.org/advisories/RUSTSEC-2021-0023.html). Previously, rand were depending on a vulnerable rand_core version, with `^0.8` this will not be the case any more. By looking at the rand changelog, nothing seems to affect the basic function this project is using. The biggest change is the default feature added in `0.8` which we need to have access to the `thread_rng` function.

Add some tests before the upgrade, so the new version still behavior the same.