### PR TITLE
Fix full jitter ceil bias

### DIFF
--- a/src/delay/random.rs
+++ b/src/delay/random.rs
@@ -141,3 +141,9 @@ fn test_jitter() {
     assert_eq!(Duration::from_millis(0), jitter(Duration::from_millis(0)));
     assert!(Duration::from_millis(0) < jitter(Duration::from_millis(2)));
 }
+
+#[test]
+fn test_jitter_reduces_duration() {
+    let d = Duration::from_secs(1);
+    assert!((0..100).any(|_| jitter(d) < d));
+}

--- a/src/delay/random.rs
+++ b/src/delay/random.rs
@@ -101,10 +101,7 @@ impl From<RangeInclusive<Duration>> for Range {
 /// Apply full random jitter to a duration. (When the `random` Cargo feature is enabled.)
 #[must_use]
 pub fn jitter(duration: Duration) -> Duration {
-    let jitter = random::<f64>();
-    let secs = ((duration.as_secs() as f64) * jitter).ceil() as u64;
-    let nanos = ((f64::from(duration.subsec_nanos())) * jitter).ceil() as u32;
-    Duration::new(secs, nanos)
+    duration.mul_f64(random::<f64>())
 }
 
 #[test]

--- a/src/delay/random.rs
+++ b/src/delay/random.rs
@@ -138,9 +138,3 @@ fn test_jitter() {
     assert_eq!(Duration::from_millis(0), jitter(Duration::from_millis(0)));
     assert!(Duration::from_millis(0) < jitter(Duration::from_millis(2)));
 }
-
-#[test]
-fn test_jitter_reduces_duration() {
-    let d = Duration::from_secs(1);
-    assert!((0..100).any(|_| jitter(d) < d));
-}


### PR DESCRIPTION
## Summary
- The previous `jitter` implementation separately applied `ceil()` to the seconds and nanoseconds components, causing severe upward bias. For example, `jitter(Duration::from_secs(1))` always returned exactly 1 second.
- Replace the manual computation with `duration.mul_f64()`, which correctly scales the entire duration.